### PR TITLE
feat: added routes to delete a user and retrieve all users

### DIFF
--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 
 import prisma from "./../../lib/prisma-client.js";
-import { getUser, getUserById } from "./routes.js";
+import { getAllUsers, getUser, getUserById } from "./routes.js";
 
 import { Role } from "@prisma/client";
 import { checkRole, getCurrentUser } from "../../lib/auth-provider.js";
@@ -11,6 +11,18 @@ const userRouter = new OpenAPIHono();
 userRouter.openapi(getUser, async (ctx) => {
   const user = getCurrentUser(ctx);
   return ctx.json(user, 200);
+});
+
+userRouter.openapi(getAllUsers, async (ctx) => {
+  if (!checkRole([Role.ADMIN, Role.SUPER_ADMIN], ctx)) {
+    return ctx.text("Forbidden", 403);
+  }
+  const users = await prisma.user.findMany({
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+  return ctx.json(users);
 });
 
 userRouter.openapi(getUserById, async (ctx) => {

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 
 import prisma from "./../../lib/prisma-client.js";
-import { getAllUsers, getUser, getUserById } from "./routes.js";
+import { deleteUserById, getAllUsers, getUser, getUserById } from "./routes.js";
 
 import { Role } from "@prisma/client";
 import { checkRole, getCurrentUser } from "../../lib/auth-provider.js";
@@ -43,6 +43,26 @@ userRouter.openapi(getUserById, async (ctx) => {
   }
 
   return ctx.json({ user }, 200);
+});
+
+userRouter.openapi(deleteUserById, async (ctx) => {
+  if (!checkRole([Role.ADMIN, Role.SUPER_ADMIN], ctx)) {
+    return ctx.text("Forbidden", 403);
+  }
+
+  const id = ctx.req.param().id;
+
+  const user = await prisma.auth.delete({
+    where: {
+      id,
+    },
+  });
+
+  if (!user) {
+    return ctx.text("User not found", 404);
+  }
+
+  return ctx.text(`User ${id} deleted successfully`, 200);
 });
 
 export default userRouter;

--- a/src/routes/user/routes.ts
+++ b/src/routes/user/routes.ts
@@ -70,3 +70,27 @@ export const getAllUsers = createRoute({
     },
   },
 });
+
+export const deleteUserById = createRoute({
+  method: "delete",
+  path: "/{id}",
+  request: {
+    params: z.object({
+      id: z
+        .string()
+        .uuid()
+        .openapi({ example: "123e4567-e89b-12d3-a456-426614174000" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Deleted user successfully",
+    },
+    403: {
+      description: "Forbidden",
+    },
+    404: {
+      description: "User not found",
+    },
+  },
+});

--- a/src/routes/user/routes.ts
+++ b/src/routes/user/routes.ts
@@ -52,3 +52,27 @@ export const getUserById = createRoute({
     },
   },
 });
+
+export const getAllUsers = createRoute({
+  method: "get",
+  path: "/all",
+  responses: {
+    200: {
+      description: "Retrieved all users",
+      content: {
+        "application/json": {
+          schema: z
+            .array(
+              z.object({
+                user: UserSchema,
+              })
+            )
+            .openapi("UsersResponse"),
+        },
+      },
+    },
+    403: {
+      description: "Forbidden",
+    },
+  },
+});

--- a/src/routes/user/routes.ts
+++ b/src/routes/user/routes.ts
@@ -56,6 +56,11 @@ export const getUserById = createRoute({
 export const getAllUsers = createRoute({
   method: "get",
   path: "/all",
+  security: [
+    {
+      Bearer: [],
+    },
+  ],
   responses: {
     200: {
       description: "Retrieved all users",
@@ -74,6 +79,11 @@ export const getAllUsers = createRoute({
 export const deleteUserById = createRoute({
   method: "delete",
   path: "/{id}",
+  security: [
+    {
+      Bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       id: z

--- a/src/routes/user/routes.ts
+++ b/src/routes/user/routes.ts
@@ -61,13 +61,7 @@ export const getAllUsers = createRoute({
       description: "Retrieved all users",
       content: {
         "application/json": {
-          schema: z
-            .array(
-              z.object({
-                user: UserSchema,
-              })
-            )
-            .openapi("UsersResponse"),
+          schema: z.array(UserSchema).openapi("UsersResponse"),
         },
       },
     },


### PR DESCRIPTION
- Added `GET /user/all` route to view all users in decreasing order of creation time, accessed only by `ADMIN` and `SUPER_ADMIN` roles.
- Added `DELETE /user/{id}` route to delete a user by their ID, accessed only by `ADMIN` and `SUPER_ADMIN` roles.

Potentially finishes all of #11 functionality.