### PR TITLE
feat: added showcase router

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import userRouter from "./routes/user/index.js";
 import teamRouter from "./routes/teams/index.js";
 import projectRouter from "./routes/project/index.js";
 import evaluationRouter from "./routes/evalutation/index.js";
+import showcaseRouter from "./routes/showcase/index.js";
+
 import { jwt } from "hono/jwt";
 import type { JwtVariables } from "hono/jwt";
 
@@ -30,6 +32,7 @@ app.route("/auth", authRouter);
 app.get("/", (c) => {
   return c.text("Server is alive!");
 });
+app.route("/showcase", showcaseRouter);
 
 app.doc("/openapi", {
   openapi: "3.0.0",
@@ -55,7 +58,7 @@ app.use(
 app.route("/user", userRouter);
 app.route("/team", teamRouter);
 app.route("/evaluation", evaluationRouter);
-app.route('/project', projectRouter)
+app.route("/project", projectRouter);
 
 const port = 3000;
 console.log(`Server is running on http://localhost:${port}`);

--- a/src/routes/showcase/index.ts
+++ b/src/routes/showcase/index.ts
@@ -1,0 +1,16 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import prisma from "../../lib/prisma-client.js";
+import { getProjectsShowcase } from "./routes.js";
+
+const showcaseRouter = new OpenAPIHono();
+
+showcaseRouter.openapi(getProjectsShowcase, async (ctx) => {
+  const projects = await prisma.project.findMany({
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+  return ctx.json(projects, 200);
+});
+
+export default showcaseRouter;

--- a/src/routes/showcase/routes.ts
+++ b/src/routes/showcase/routes.ts
@@ -1,0 +1,21 @@
+import { z, createRoute } from "@hono/zod-openapi";
+import { ProjectSchema } from "../../schemas/project.js";
+
+export const getProjectsShowcase = createRoute({
+  method: "get",
+  path: "/projects",
+  tags: ["Showcase"],
+  responses: {
+    200: {
+      description: "Successfully retrieved all projects.",
+      content: {
+        "application/json": {
+          schema: z.array(ProjectSchema),
+        },
+      },
+    },
+    500: {
+      description: "Unexpected server error.",
+    },
+  },
+});

--- a/src/routes/showcase/routes.ts
+++ b/src/routes/showcase/routes.ts
@@ -5,6 +5,8 @@ export const getProjectsShowcase = createRoute({
   method: "get",
   path: "/projects",
   tags: ["Showcase"],
+  description:
+    "Fetches a list of all the projects. Can be accessed by unauthenticated users.",
   responses: {
     200: {
       description: "Successfully retrieved all projects.",


### PR DESCRIPTION
New Endpoints:
- `/showcase/projects`: Retrieves all projects for showcase